### PR TITLE
adding content and content relationship files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-### 1. Update Prismic CTS to use SharedSlices
+Untested.
 
-Note that this does not migrate content that relies on Non Shared Slices.
+## 1. Update Prismic CTS to use SharedSlices
 
 Create a `.env` file with `TOKEN` (prismic-auth) and `REPO` values.
 
@@ -10,4 +10,32 @@ node migrate-cts.mjs
 ````
 
 This will create customtypes ans slices folders.
-Untested.
+In the custom type folder, rename the custom type by adding a "2" at the end of their ID and Name to distinguish old and new custom types.
+Then push newly created custom types and slices through slice machine.
+
+## 2. Adapt your documents to SharedSlices format
+
+Note that this process needs to be split into parts if there are more than 200 documents, as the Import module lets you upload a ZIP archive containing up to 200 JSON files, each file representing the content for one Prismic document.
+
+Create the following folders at the root of your project, to handle different versions of your document
+
+![image](https://user-images.githubusercontent.com/89452979/141962485-128051db-a357-45f4-9046-b6afbd9f8855.png)
+
+### a. Change the formatting of your document
+ 
+Export your documents from the Prismic export feature. 
+Place the extracted json files in "content/export_old_docs" folder.
+
+Then run migration-content.js.
+
+This will create a zip in the new_content_zip folder.
+Upload this zip with the Prismic Import feature into your repo.
+
+### b. Change content relationships (Have them point to newly created documents)
+
+Export a second time your documents from the Prismic export feature. 
+Place the extracted json files in "content/new_files_export_before_content_rel" folder
+
+Then run migration-cr.js to change content relationships
+
+Finally you can upload the zip located in new_files_final_zip into your repo.

--- a/migration-content.js
+++ b/migration-content.js
@@ -1,0 +1,60 @@
+
+const fs = require('fs');
+const path = require('path');
+const directoryPath = path.join(__dirname, 'content/export_old_docs');
+const archiver = require('archiver');
+
+function migrateContent() {
+
+    //passsing directoryPath and callback function
+    fs.readdir(directoryPath, function (err, files) {
+        //handling error
+        if (err) {
+            return console.log('Unable to scan directory: ' + err);
+        } 
+        //listing all files using forEach
+        files.forEach(function (file,index) {
+            // Do whatever you want to do with the file
+            if(!file.startsWith(".")){
+                const fileData = require(path.join(__dirname, 'content/export_old_docs',file));
+                if(fileData.body){
+                    fileData.body.forEach(function(slice){
+                        slice.value.variation="default-slice"
+                        slice.value.items=slice.value.repeat
+                        delete slice.value.repeat
+                        slice.value.primary=slice.value["non-repeat"]
+                        delete slice.value["non-repeat"]
+                    })
+                }
+                if(fileData.type){
+                    fileData.type=fileData.type+"2"
+                }
+                fs.writeFile(path.join(__dirname, 'content/new_content',index+"_migrated.json"), JSON.stringify(fileData, null, 2), function writeJSON(err) {
+                if (err) return console.log(err);
+                console.log('writing to ' + path.join(__dirname, 'content/new_content',index+"_migrated.json"));
+                });
+            }
+        });
+
+        var output = fs.createWriteStream('new_content_zip/target.zip');
+        var archive = archiver('zip');
+
+        output.on('close', function () {
+            console.log(archive.pointer() + ' total bytes');
+            console.log('archiver has been finalized and the output file descriptor has closed.');
+        });
+
+        archive.on('error', function(err){
+            throw err;
+        });
+
+        archive.pipe(output);
+
+        // append files from a sub-directory, putting its contents at the root of archive
+        archive.directory("content/new_content", false);
+
+        archive.finalize();
+    });
+}
+
+migrateContent()

--- a/migration-cr.js
+++ b/migration-cr.js
@@ -1,0 +1,124 @@
+const Prismic = require('@prismicio/client');
+const dotenv = require('dotenv')
+const fs = require('fs');
+const path = require('path');
+const archiver = require('archiver');
+
+dotenv.config()
+
+// Update your-repo-name with the name of your repository.
+const apiEndpoint = "https://"+process.env.REPO+".cdn.prismic.io/api/v2"
+const Client = Prismic.client(apiEndpoint)
+
+const directoryPath = path.join(__dirname, 'content/new_files_export_before_content_rel');
+
+//build a comparison table between old documents of type TYPE with new documents of type TYPE2
+async function getComparisonTable(){
+    let table=[{"type":null,"uid":null,"old":null,"new":null}];
+    const document = await Client.query('')
+    let i = 0;
+    document.results.forEach((element) => {
+        if(element.type.substr(element.type.length - 1) !== '2' ){
+            table[i]={}
+            table[i].type= element.type
+            table[i].uid= element.uid
+            table[i].old= element.id
+            i++
+        }
+    });
+    const document2 = await Client.query('')
+    document2.results.forEach((element) => {
+        if(element.type.substr(element.type.length - 1) === '2' ){
+            index = table.findIndex( line => line.uid === element.uid && line.type === element.type.substring(0, element.type.length - 1) );
+            table[index].new=element.id
+        }
+    });
+    return(table)
+}
+
+//Update all content relationship links in all new documents (TYPE2) from old TYPE documentID to new TYPE2 documentId
+async function updateContentRelationships() {
+
+    const comparisonTable= await getComparisonTable();
+
+    //passsing directoryPath and callback function
+    fs.readdir(directoryPath, function (err, files) {
+        //handling error
+        if (err) {
+            return console.log('Unable to scan directory: ' + err);
+        } 
+        //listing all files using forEach
+        files.forEach(function (file) {
+            // Do whatever you want to do with the file
+            if(!file.startsWith(".")){
+                const fileData = require(path.join(__dirname, 'content/new_files_export_before_content_rel',file));
+                if(fileData.type.substr(fileData.type.length - 1) === '2' ){
+                    //look for CR links in primary section
+                    Object.keys(fileData).forEach(function(field){
+                        if(fileData[field].wioUrl !== undefined){
+                            newContentId = comparisonTable.find( item => item.old === fileData[field].id).new ;
+                            fileData[field].wioUrl = "wio://documents/" + newContentId;
+                            fileData[field].id = newContentId;
+                        }
+                        if(Array.isArray(fileData[field])){
+                            fileData[field].forEach(function(subField,index){
+                                Object.keys(fileData[field][index]).forEach(function(subField){
+                                    if(fileData[field][index][subField].wioUrl !== undefined){
+                                        newContentId = comparisonTable.find( item => item.old === fileData[field][index][subField].id).new ;
+                                        fileData[field][index][subField].wioUrl = "wio://documents/" + newContentId;
+                                        fileData[field][index][subField].id = newContentId;
+                                    }
+                                })
+                            })
+                        }
+                    })
+                    // look for CR links in slices
+                    fileData.body.forEach(function(slice){
+                        Object.keys(slice.value.primary).forEach(function(field){
+                            if(slice.value.primary[field].wioUrl !== undefined){
+                                newContentId = comparisonTable.find( item => item.old === slice.value.primary[field].id).new ;
+                                slice.value.primary[field].wioUrl = "wio://documents/" + newContentId;
+                                slice.value.primary[field].id = newContentId;
+                            }
+                        })
+                        slice.value.items.forEach(function(field,index){
+                            Object.keys(slice.value.items[index]).forEach(function(subField){
+                                if(slice.value.items[index][subField].wioUrl !== undefined){
+                                    newContentId = comparisonTable.find( item => item.old === slice.value.items[index][subField].id).new ;
+                                    slice.value.items[index][subField].wioUrl = "wio://documents/" + newContentId;
+                                    slice.value.items[index][subField].id = newContentId;
+                                }
+                            })
+                        })
+                    })
+                    fs.writeFile(path.join(__dirname, 'content/new_files_final',file), JSON.stringify(fileData, null, 2), function writeJSON(err) {
+                    if (err) return console.log(err);
+                    console.log('writing to ' + path.join(__dirname, 'content/new_files_final',file));
+                    });
+                }
+            }
+        });
+
+        var output = fs.createWriteStream('new_files_final_zip/target.zip');
+        var archive = archiver('zip');
+
+        output.on('close', function () {
+            console.log(archive.pointer() + ' total bytes');
+            console.log('archiver has been finalized and the output file descriptor has closed.');
+        });
+
+        archive.on('error', function(err){
+            throw err;
+        });
+
+        archive.pipe(output);
+
+        // append files from a sub-directory, putting its contents at the root of archive
+        archive.directory("content/new_files_final", false);
+
+        archive.finalize();
+    });
+}
+
+//run it
+    updateContentRelationships()

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@prismicio/client": "^5.1.0",
+    "archiver": "^5.3.0",
     "dotenv": "^10.0.0",
-    "node-fetch": "^3.0.0",
-    "slice-machine-ui": "^0.1.0"
+    "slice-machine-ui": "^0.1.1",
+    "node-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
Adding two other files:
migration-content.js is transforming the content to the new custom type (TYPE --> TYPE2)
migration-cr.js is then building a comparison table between old and new documents, and then replaces all document ids in the new exported docs to fix content relationships

Flow is this:

you run migration-cts.js and then push custom types and slices through slice machine
you export current content in "content/export_old_docs" folder and then run migration-content.js on it
you import content/new_content in your repo
you export all content from your repo in new_files_export_before_content_rel and then run migration-cr.js to fix content relationships
you import the final content